### PR TITLE
Fix typos in source comments and user-facing output

### DIFF
--- a/AnimateDocumentObserver.py
+++ b/AnimateDocumentObserver.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -194,7 +194,7 @@ Returns:
 Method testing whether a forbidden object is in an `Animate` group object.
 
 Trajectory group objects are allowed to be stacked. Control objects can contain
-any other `Animate` object. CollisionDetector objects can accomodate only
+any other `Animate` object. CollisionDetector objects can accommodate only
 Collision objects.
 
 Args:
@@ -244,7 +244,7 @@ is going to be closed.
 Args:
     doc: A FreeCAD's `App.Document` document about to be closed.
         """
-        # Check atleast one server is in the document about to be closed
+        # Check at least one server is in the document about to be closed
         if doc.Name in self.server_proxies:
             # Notify all servers in the document
             for server_proxy in self.server_proxies[doc.Name]:
@@ -276,7 +276,7 @@ def addObserver():
     """
 Adds an `AnimateDocumentObserver` between FreeCAD's document observers safely.
 
-It's prefered to add an `AnimateDocumentObserver` using this method, because
+It's preferred to add an `AnimateDocumentObserver` using this method, because
 other ways could result in having multiple document observers added to FreeCAD.
 Having a lot of document observers slows down FreeCAD due to necessity to
 inform them all about imminent changes and so on.

--- a/CollisionDetector.py
+++ b/CollisionDetector.py
@@ -3,7 +3,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -552,7 +552,7 @@ Args:
         """
         # Add new object to the CollisionDetector
         collision = self.fp.newObject("Part::FeaturePython", "Collision")
-        # Attach a Proxy ot it and it's ViewObject, then purge its touched flag
+        # Attach a Proxy to it and it's ViewObject, then purge its touched flag
         CollisionProxy(collision, shape, cause1, cause2)
         ViewProviderCollisionProxy(collision.ViewObject, color)
         collision.purgeTouched()
@@ -660,7 +660,7 @@ Args:
 Method to postpone execution after coin is finished (and avoid crashing coin).
 
 Removing objects is necessary to do using this method, otherwise coin will
-crash. When using with variable or arguments, its crutial that they stay
+crash. When using with variable or arguments, its crucial that they stay
 available and unchanged until the command is executed.
 
 Usage example:
@@ -912,7 +912,7 @@ Returns:
 
 class CollisionDetectorCommand(object):
     """
-Class specifing Animate workbench's CollisionDetector button/command.
+Class specifying Animate workbench's CollisionDetector button/command.
 
 This class provides resources for a toolbar button and a menu button.
 It controls their behaivor(Active/Inactive) and responds to callbacks after

--- a/CollisionObject.py
+++ b/CollisionObject.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -164,7 +164,7 @@ Args:
         """
 Method called when CollisionDetector is double-clicked in the Tree View.
 
-It just prevents user from accessing transfromation panel and transforming
+It just prevents user from accessing transformation panel and transforming
 a `Collision` object. It's enough to just implement it and return `True` for
 this purpose.
 
@@ -203,7 +203,7 @@ Returns:
         """
 Method to hide unused properties.
 
-All unused unneccesary `FeaturePython`s properties are hidden except for
+All unused unnecessary `FeaturePython`s properties are hidden except for
 `Transparency` and `Visibility`.
 
 Args:

--- a/Control.py
+++ b/Control.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -317,14 +317,14 @@ Feedback method called when Control panel is closing.
 Animation is stopped. Controls properties are set to be editable. Dialog is
 closed.
         """
-        # Stop animaiton, if it's running by clicking pause button
+        # Stop animation, if it's running by clicking pause button
         self.pauseClicked()
 
         # Allow editing of Control properties again
         for prop in self.control_proxy.PropertiesList:
             self.control_proxy.setEditorMode(prop, 0)
 
-        # Delete refrence to this panel from the view provider as the panel
+        # Delete reference to this panel from the view provider as the panel
         # will no longer exist
         self.control_proxy.ViewObject.Proxy.panel = None
 
@@ -395,7 +395,7 @@ Args:
         self.updateCollisions()
         self.showChanges()
 
-        # Display current progres on the seek slider
+        # Display current progress on the seek slider
         self.form.sld_seek.setValue(
             numpy.round(100*(t - self.control_proxy.StartTime)
                         / (self.control_proxy.StopTime
@@ -411,13 +411,13 @@ Args:
         next_t = min(t + self.control_proxy.StepTime,
                      self.control_proxy.StopTime)
 
-        # Compute pause period so that animaiton time roughly corresponds to
+        # Compute pause period so that animation time roughly corresponds to
         # the real time
         pause = round(1000*(self.control_proxy.StepTime + time_
                             - time.clock()))
         pause = pause*(pause > 0)
 
-        # Setup a timer to show next frame if animaiton wasn't paused
+        # Setup a timer to show next frame if animation wasn't paused
         if self.last_clicked != "pause":
             self.timer.singleShot(pause, lambda: self.play(next_t))
 
@@ -449,7 +449,7 @@ Args:
         self.updateCollisions()
         self.showChanges()
 
-        # Display current progres on the seek slider
+        # Display current progress on the seek slider
         self.form.sld_seek.setValue(
                 numpy.round(100*(t - self.control_proxy.StartTime)
                             / (self.control_proxy.StopTime
@@ -465,13 +465,13 @@ Args:
         next_t = max(t - self.control_proxy.StepTime,
                      self.control_proxy.StartTime)
 
-        # Compute pause period so that animaiton time roughly corresponds to
+        # Compute pause period so that animation time roughly corresponds to
         # the real time
         pause = round(1000*(self.control_proxy.StepTime + time_
                             - time.clock()))
         pause = pause*(pause > 0)
 
-        # Setup a timer to show next frame if animaiton wasn't paused
+        # Setup a timer to show next frame if animation wasn't paused
         if self.last_clicked != "pause":
             self.timer.singleShot(pause, lambda: self.rewind(next_t))
 
@@ -502,7 +502,7 @@ Args:
         self.showChanges()
         self.saveImage()
 
-        # Display current progres on the seek slider
+        # Display current progress on the seek slider
         self.form.sld_seek.setValue(
                 numpy.round(100*(t - self.control_proxy.StartTime)
                             / (self.control_proxy.StopTime
@@ -518,7 +518,7 @@ Args:
         next_t = min(t + self.control_proxy.StepTime,
                      self.control_proxy.StopTime)
 
-        # Setup a timer to show next frame if animaiton wasn't paused
+        # Setup a timer to show next frame if animation wasn't paused
         if self.last_clicked != "pause":
             self.timer.singleShot(0, lambda: self.record(next_t))
 
@@ -790,7 +790,7 @@ Feedback method called when confirm button was clicked.
 
 Buttons are disabled, framerate is loaded from the first image chunks,
 selected sequence name is used to create an `image name` template and
-a `video name` which can be used in a FFMPEG command. Such a commnad
+a `video name` which can be used in a FFMPEG command. Such a command
 is executed to convert the video, if FFMPEG is installed.
 Otherwise warnings are shown.
         """
@@ -836,11 +836,11 @@ Otherwise warnings are shown.
             else:
                 QMessageBox.warning(None, 'Something failed', str(e))
         if return_val == 0:
-            QMessageBox.information(None, 'Export successfull!',
+            QMessageBox.information(None, 'Export successful!',
                                     "FFMPEG successfully converted image "
                                     + "sequence into a video.")
         else:
-            QMessageBox.warning(None, 'FFMPEG unsuccessfull',
+            QMessageBox.warning(None, 'FFMPEG unsuccessful',
                                 "FFMPEG failed to convert sequence into "
                                 + "a video")
 
@@ -880,7 +880,7 @@ is returned to the default state (the same as if pause button was pressed).
 Method to install necessary pyPNG library into FreeCAD.
 
 The pyPNG library is not part of FreeCAD and so we need to add it using pip.
-This method tries to do so. It may prove crutial to run FreeCAD as
+This method tries to do so. It may prove crucial to run FreeCAD as
 administrator to receive permissions required by pip.
 
 Returns:
@@ -904,7 +904,7 @@ Returns:
                 return True
             else:
                 FreeCAD.Console.PrintLog(
-                        "Unable to import and instal pyPNG.\n")
+                        "Unable to import and install pyPNG.\n")
                 return False
 
     def writeFramerateChunk(self, framerate, image_path):
@@ -930,8 +930,8 @@ Args:
             else:
                 return False
         except Exception as e:
-            FreeCAD.Consol.PrintError(
-                "Unexpected error occured while importing pyPNG - " + str(e))
+            FreeCAD.Console.PrintError(
+                "Unexpected error occurred while importing pyPNG - " + str(e))
 
         # Read chunks already present in a PNG image
         reader = png.Reader(filename=image_path)
@@ -1229,7 +1229,7 @@ then invokes `claimChildren()`.
 
     def canDropObject(self, obj):
         """
-Method called by FreeCAD to ask if an object `obj` can be droped into a Group.
+Method called by FreeCAD to ask if an object `obj` can be dropped into a Group.
 
 FreeCAD objects of a Server, Trajectory and CollisionDetector type are allowed
 to drop inside a Control group.
@@ -1275,7 +1275,7 @@ Method called by FreeCAD when Control is double-clicked in the Tree View.
 
 If no dialog is opened in the Task View, a new `ControlPanel` is opened.
 If a `ControlPanel` is already opened, the Model tab on the Combo View
-is swaped for the Tasks tab so that the panel becomes visible.
+is swapped for the Tasks tab so that the panel becomes visible.
 If another dialog is opened a warning is shown.
 
 Args:
@@ -1352,7 +1352,7 @@ to reset it.
 
 class ControlCommand(object):
     """
-ControlCommand class specifing Animate workbench's Control button/command.
+ControlCommand class specifying Animate workbench's Control button/command.
 
 This class provides resources for a toolbar button and a menu button.
 It controls their behaivor(Active/Inactive) and responds to callbacks after

--- a/Doxygen/Doxyfile
+++ b/Doxygen/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         = v0.01
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "FreeCAD Workbench for lightweigh animation"
+PROJECT_BRIEF          = "FreeCAD Workbench for lightweight animation"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/Doxygen/Doxypypy outputs/AnimateDocumentObserver.py
+++ b/Doxygen/Doxypypy outputs/AnimateDocumentObserver.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -201,7 +201,7 @@ class AnimateDocumentObserver(object):
     ## @brief Method testing whether a forbidden object is in an `Animate` group object.
     #
     #Trajectory group objects are allowed to be stacked. Control objects can contain
-    #any other `Animate` object. CollisionDetector objects can accomodate only
+    #any other `Animate` object. CollisionDetector objects can accommodate only
     #Collision objects.
     #
     #
@@ -253,7 +253,7 @@ class AnimateDocumentObserver(object):
     #
 
     def slotDeletedDocument(self, doc):
-        # Check atleast one server is in the document about to be closed
+        # Check at least one server is in the document about to be closed
         if doc.Name in self.server_proxies:
             # Notify all servers in the document
             for server_proxy in self.server_proxies[doc.Name]:
@@ -283,7 +283,7 @@ class AnimateDocumentObserver(object):
 
 ## @brief Adds an `AnimateDocumentObserver` between FreeCAD's document observers safely.
 #
-#It's prefered to add an `AnimateDocumentObserver` using this method, because
+#It's preferred to add an `AnimateDocumentObserver` using this method, because
 #other ways could result in having multiple document observers added to FreeCAD.
 #Having a lot of document observers slows down FreeCAD due to necessity to
 #inform them all about imminent changes and so on.

--- a/Doxygen/Doxypypy outputs/CollisionDetector.py
+++ b/Doxygen/Doxypypy outputs/CollisionDetector.py
@@ -3,7 +3,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -571,7 +571,7 @@ class CollisionDetectorProxy(object):
     def makeCollisionObject(self, shape, cause1, cause2, color):
         # Add new object to the CollisionDetector
         collision = self.fp.newObject("Part::FeaturePython", "Collision")
-        # Attach a Proxy ot it and it's ViewObject, then purge its touched flag
+        # Attach a Proxy to it and it's ViewObject, then purge its touched flag
         CollisionProxy(collision, shape, cause1, cause2)
         ViewProviderCollisionProxy(collision.ViewObject, color)
         collision.purgeTouched()
@@ -677,7 +677,7 @@ class CollisionDetectorProxy(object):
     ## @brief Method to postpone execution after coin is finished (and avoid crashing coin).
     #
     #Removing objects is necessary to do using this method, otherwise coin will
-    #crash. When using with variable or arguments, its crutial that they stay
+    #crash. When using with variable or arguments, its crucial that they stay
     #available and unchanged until the command is executed.
     #
     #Usage example:
@@ -932,7 +932,7 @@ class ViewProviderCollisionDetectorProxy(object):
         return False
 
 
-## @brief Class specifing Animate workbench's CollisionDetector button/command.
+## @brief Class specifying Animate workbench's CollisionDetector button/command.
 #
 #This class provides resources for a toolbar button and a menu button.
 #It controls their behaivor(Active/Inactive) and responds to callbacks after

--- a/Doxygen/Doxypypy outputs/CollisionObject.py
+++ b/Doxygen/Doxypypy outputs/CollisionObject.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -162,7 +162,7 @@ class ViewProviderCollisionProxy(object):
 
     ## @brief Method called when CollisionDetector is double-clicked in the Tree View.
     #
-    #It just prevents user from accessing transfromation panel and transforming
+    #It just prevents user from accessing transformation panel and transforming
     #a `Collision` object. It's enough to just implement it and return `True` for
     #this purpose.
     #
@@ -201,7 +201,7 @@ class ViewProviderCollisionProxy(object):
 
     ## @brief Method to hide unused properties.
     #
-    #All unused unneccesary `FeaturePython`s properties are hidden except for
+    #All unused unnecessary `FeaturePython`s properties are hidden except for
     #`Transparency` and `Visibility`.
     #
     #

--- a/Doxygen/Doxypypy outputs/Control.py
+++ b/Doxygen/Doxypypy outputs/Control.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -338,14 +338,14 @@ class ControlPanel(QObject):
     #
 
     def reject(self):
-        # Stop animaiton, if it's running by clicking pause button
+        # Stop animation, if it's running by clicking pause button
         self.pauseClicked()
 
         # Allow editing of Control properties again
         for prop in self.control_proxy.PropertiesList:
             self.control_proxy.setEditorMode(prop, 0)
 
-        # Delete refrence to this panel from the view provider as the panel
+        # Delete reference to this panel from the view provider as the panel
         # will no longer exist
         self.control_proxy.ViewObject.Proxy.panel = None
 
@@ -416,7 +416,7 @@ class ControlPanel(QObject):
         self.updateCollisions()
         self.showChanges()
 
-        # Display current progres on the seek slider
+        # Display current progress on the seek slider
         self.form.sld_seek.setValue(
             numpy.round(100*(t - self.control_proxy.StartTime)
                         / (self.control_proxy.StopTime
@@ -432,13 +432,13 @@ class ControlPanel(QObject):
         next_t = min(t + self.control_proxy.StepTime,
                      self.control_proxy.StopTime)
 
-        # Compute pause period so that animaiton time roughly corresponds to
+        # Compute pause period so that animation time roughly corresponds to
         # the real time
         pause = round(1000*(self.control_proxy.StepTime + time_
                             - time.clock()))
         pause = pause*(pause > 0)
 
-        # Setup a timer to show next frame if animaiton wasn't paused
+        # Setup a timer to show next frame if animation wasn't paused
         if self.last_clicked != "pause":
             self.timer.singleShot(pause, lambda: self.play(next_t))
 
@@ -470,7 +470,7 @@ class ControlPanel(QObject):
         self.updateCollisions()
         self.showChanges()
 
-        # Display current progres on the seek slider
+        # Display current progress on the seek slider
         self.form.sld_seek.setValue(
                 numpy.round(100*(t - self.control_proxy.StartTime)
                             / (self.control_proxy.StopTime
@@ -486,13 +486,13 @@ class ControlPanel(QObject):
         next_t = max(t - self.control_proxy.StepTime,
                      self.control_proxy.StartTime)
 
-        # Compute pause period so that animaiton time roughly corresponds to
+        # Compute pause period so that animation time roughly corresponds to
         # the real time
         pause = round(1000*(self.control_proxy.StepTime + time_
                             - time.clock()))
         pause = pause*(pause > 0)
 
-        # Setup a timer to show next frame if animaiton wasn't paused
+        # Setup a timer to show next frame if animation wasn't paused
         if self.last_clicked != "pause":
             self.timer.singleShot(pause, lambda: self.rewind(next_t))
 
@@ -523,7 +523,7 @@ class ControlPanel(QObject):
         self.showChanges()
         self.saveImage()
 
-        # Display current progres on the seek slider
+        # Display current progress on the seek slider
         self.form.sld_seek.setValue(
                 numpy.round(100*(t - self.control_proxy.StartTime)
                             / (self.control_proxy.StopTime
@@ -539,7 +539,7 @@ class ControlPanel(QObject):
         next_t = min(t + self.control_proxy.StepTime,
                      self.control_proxy.StopTime)
 
-        # Setup a timer to show next frame if animaiton wasn't paused
+        # Setup a timer to show next frame if animation wasn't paused
         if self.last_clicked != "pause":
             self.timer.singleShot(0, lambda: self.record(next_t))
 
@@ -809,7 +809,7 @@ class ControlPanel(QObject):
     #
     #Buttons are disabled, framerate is loaded from the first image chunks,
     #selected sequence name is used to create an `image name` template and
-    #a `video name` which can be used in a FFMPEG command. Such a commnad
+    #a `video name` which can be used in a FFMPEG command. Such a command
     #is executed to convert the video, if FFMPEG is installed.
     #Otherwise warnings are shown.
     #
@@ -857,11 +857,11 @@ class ControlPanel(QObject):
             else:
                 QMessageBox.warning(None, 'Something failed', str(e))
         if return_val == 0:
-            QMessageBox.information(None, 'Export successfull!',
+            QMessageBox.information(None, 'Export successful!',
                                     "FFMPEG successfully converted image "
                                     + "sequence into a video.")
         else:
-            QMessageBox.warning(None, 'FFMPEG unsuccessfull',
+            QMessageBox.warning(None, 'FFMPEG unsuccessful',
                                 "FFMPEG failed to convert sequence into "
                                 + "a video")
 
@@ -899,7 +899,7 @@ class ControlPanel(QObject):
     ## @brief Method to install necessary pyPNG library into FreeCAD.
     #
     #The pyPNG library is not part of FreeCAD and so we need to add it using pip.
-    #This method tries to do so. It may prove crutial to run FreeCAD as
+    #This method tries to do so. It may prove crucial to run FreeCAD as
     #administrator to receive permissions required by pip.
     #
     # @return
@@ -925,7 +925,7 @@ class ControlPanel(QObject):
                 return True
             else:
                 FreeCAD.Console.PrintLog(
-                        "Unable to import and instal pyPNG.\n")
+                        "Unable to import and install pyPNG.\n")
                 return False
 
     ## @brief Method to write a framerate into a PNG image as one of its chunks.
@@ -952,7 +952,7 @@ class ControlPanel(QObject):
                 return False
         except Exception as e:
             FreeCAD.Consol.PrintError(
-                "Unexpected error occured while importing pyPNG - " + str(e))
+                "Unexpected error occurred while importing pyPNG - " + str(e))
 
         # Read chunks already present in a PNG image
         reader = png.Reader(filename=image_path)
@@ -1258,7 +1258,7 @@ class ViewProviderControlProxy:
                 return self.fp.Group
         return []
 
-    ## @brief Method called by FreeCAD to ask if an object `obj` can be droped into a Group.
+    ## @brief Method called by FreeCAD to ask if an object `obj` can be dropped into a Group.
     #
     #FreeCAD objects of a Server, Trajectory and CollisionDetector type are allowed
     #to drop inside a Control group.
@@ -1304,7 +1304,7 @@ class ViewProviderControlProxy:
     #
     #If no dialog is opened in the Task View, a new `ControlPanel` is opened.
     #If a `ControlPanel` is already opened, the Model tab on the Combo View
-    #is swaped for the Tasks tab so that the panel becomes visible.
+    #is swapped for the Tasks tab so that the panel becomes visible.
     #If another dialog is opened a warning is shown.
     #
     #
@@ -1381,7 +1381,7 @@ class ViewProviderControlProxy:
         pass
 
 
-## @brief ControlCommand class specifing Animate workbench's Control button/command.
+## @brief ControlCommand class specifying Animate workbench's Control button/command.
 #
 #This class provides resources for a toolbar button and a menu button.
 #It controls their behaivor(Active/Inactive) and responds to callbacks after

--- a/Doxygen/Doxypypy outputs/Init.py
+++ b/Doxygen/Doxypypy outputs/Init.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *

--- a/Doxygen/Doxypypy outputs/InitGui.py
+++ b/Doxygen/Doxypypy outputs/InitGui.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *

--- a/Doxygen/Doxypypy outputs/Server.py
+++ b/Doxygen/Doxypypy outputs/Server.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -140,7 +140,7 @@ class ServerProxy(object):
             fp.addProperty("App::PropertyIntegerConstraint", "Port",
                            "Server settings", "Port where the server will "
                            + "listen for connections.\n" +
-                           "Valid port numers are in range <0 | 65535>,\n"
+                           "Valid port numbers are in range <0 | 65535>,\n"
                            + "but some may be already taken!"
                            ).Port = (54321, 0, 65535, 1)
         else:
@@ -384,7 +384,7 @@ class ViewProviderServerProxy(object):
             self._icon = path.join(PATH_TO_ICONS, "Server.xpm")
 
 
-## @brief ServerCommand class specifing Animate workbench's Server button/command.
+## @brief ServerCommand class specifying Animate workbench's Server button/command.
 #
 #This class provides resources for a toolbar button and a menu button.
 #It controls their behaivor(Active/Inactive) and responds to callbacks after

--- a/Doxygen/Doxypypy outputs/Trajectory.py
+++ b/Doxygen/Doxypypy outputs/Trajectory.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -618,7 +618,7 @@ class TrajectoryProxy:
         import AnimateDocumentObserver
         AnimateDocumentObserver.addObserver()
 
-    ## @brief Metod used to change a `Trajectory`'s trajectory.
+    ## @brief Method used to change a `Trajectory`'s trajectory.
     #
     #A `traj` dictionary containing a trajectory is tested for validity and then
     #assigned to a `Trajectory` `DocumentObjectGroupPython`.
@@ -757,7 +757,7 @@ class TrajectoryProxy:
     ## @brief Method to find weighted `timestamps` indices corresponding to a given `time`.
     #
     #If a `time` is smaller than the first timestamp, the returned indices are [0,0]
-    #with weights [1,0] as that's the closest value. Simlarly, if the `time` is
+    #with weights [1,0] as that's the closest value. Similarly, if the `time` is
     #greater than the last timestamp, the returned indices are [-1,-1] pointing to
     #the last element of a `timestamps` list with weights [1,0]. If the `time` value
     #is between the first and last timestamp, the indices belong to the closest
@@ -1207,7 +1207,7 @@ class ViewProviderTrajectoryProxy:
             return self.fp.Group
         return []
 
-    ## @brief Method called by FreeCAD to ask if an object `obj` can be droped into a Group.
+    ## @brief Method called by FreeCAD to ask if an object `obj` can be dropped into a Group.
     #
     #Only FreeCAD objects of a Trajectory type are allowed to drop inside
     #a Trajectory group.
@@ -1276,7 +1276,7 @@ class ViewProviderTrajectoryProxy:
     #If no dialog is opened in the Task View, a new `TrajectoryPanel` is opened.
     #If another `TrajectoryPanel` is opened, it is closed and all its QDialogs
     #are added to a new `TrajectoryPanel`. If a `TrajectoryPanel` is already opened,
-    #the Model tab on the Combo View is swaped for the Tasks tab so that the panel
+    #the Model tab on the Combo View is swapped for the Tasks tab so that the panel
     #becomes visible. If another dialog is opened a warning is shown.
     #
     #
@@ -1540,7 +1540,7 @@ class ViewProviderTrajectoryProxy:
         return separated_axis
 
 
-## @brief Class specifing Animate workbench's Trajectory button/command.
+## @brief Class specifying Animate workbench's Trajectory button/command.
 #
 #This class provides resources for a toolbar button and a menu button.
 #It controls their behaivor(Active/Inactive) and responds to callbacks after

--- a/Doxygen/Doxypypy outputs/communication.py
+++ b/Doxygen/Doxypypy outputs/communication.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -41,8 +41,8 @@ from PySide2.QtCore import QThread, QByteArray, QDataStream, QIODevice
 from PySide2.QtNetwork import QTcpServer, QTcpSocket, QAbstractSocket, \
                               QHostAddress
 
-## Size of uint16 in bytes used to leave space at the beggining of each message
-# to specify tcp message lenght (maximal length is 65535 bytes).
+## Size of uint16 in bytes used to leave space at the beginning of each message
+# to specify tcp message length (maximal length is 65535 bytes).
 SIZEOF_UINT16 = 2
 
 ## Error code used in startServer() when trying to connect CommandServer to an
@@ -53,15 +53,15 @@ SERVER_ERROR_INVALID_ADDRESS = 1
 # occupied port.
 SERVER_ERROR_PORT_OCCUPIED = 2
 
-## Time to wait in miliseconds - used to wait for incomming message etc.
+## Time to wait in milliseconds - used to wait for incoming message etc.
 WAIT_TIME_MS = 30000
 
 ## Message send from a `CommandServer` to a `CommandClient.sendCommand()` or
-# `sendClientCommand()` after successfull execution of a command.
+# `sendClientCommand()` after successful execution of a command.
 COMMAND_EXECUTED_CONFIRMATION_MESSAGE = "Command executed successfully"
 
 ## `CommandClient.sendCommand()` or `sendClientCommand()` return value after
-# confirmation of successfull command execution.
+# confirmation of successful command execution.
 CLIENT_COMMAND_EXECUTED = 0
 
 ## `CommandClient.sendCommand()` or `sendClientCommand()` return value if
@@ -89,7 +89,7 @@ CLIENT_ERROR_NO_CONNECTION = 5
 #
 #This class describes a `QThread` used to receive a command string from
 #a `QTcpSocket`, try to execute received string and send a repspondse
-#whether the execution was successfull or not.
+#whether the execution was successful or not.
 #
 #
 #
@@ -100,7 +100,7 @@ class CommandThread(QThread):
     # A Qt's qintptr socket descriptor to initialize tcpSocket.
 
     ## @property		blockSize
-    # An int representing size of incomming tcp message.
+    # An int representing size of incoming tcp message.
 
     ## @brief Initialization method for CommandThread.
     #
@@ -121,22 +121,22 @@ class CommandThread(QThread):
     #
     #The starting point for the thread. After calling start(), the newly created
     #thread calls this function. This function then tries to make QTcpSocket.
-    #It waits `WAIT_TIME_MS` for an incomming message. If message is received
+    #It waits `WAIT_TIME_MS` for an incoming message. If message is received
     #it checks its a whole message using blockSize sent in the first word as
     #an UINT16 number. If a whole message is received, the thread tries to execute
     #the message string and sends back an appropriate response. The response is
-    #*Command failed - "error string"* if the execution failed, or *Commmand
+    #*Command failed - "error string"* if the execution failed, or *Command
     #executed successfully* otherwise. Then the thread is terminated.
     #
 
     def run(self):
-        # Try to connect to an incomming tcp socket using its socket descriptor
+        # Try to connect to an incoming tcp socket using its socket descriptor
         tcpSocket = QTcpSocket()
         if not tcpSocket.setSocketDescriptor(self.socketDescriptor):
             FreeCAD.Console.PrintError("Socket not accepted.\n")
             return
 
-        # Wait for an incomming message
+        # Wait for an incoming message
         if not tcpSocket.waitForReadyRead(msecs=WAIT_TIME_MS):
             FreeCAD.Console.PrintError("No request send.\n")
             return
@@ -168,7 +168,7 @@ class CommandThread(QThread):
                                        + str(e) + "\n")
             message = "Command failed - " + str(e)
         else:
-            FreeCAD.Console.PrintLog("Executing external command succeded!\n")
+            FreeCAD.Console.PrintLog("Executing external command succeeded!\n")
             message = COMMAND_EXECUTED_CONFIRMATION_MESSAGE
 
         # Prepare the data block to send back and inform about it
@@ -205,9 +205,9 @@ class CommandServer(QTcpServer):
     def __init__(self, parent=None):
         super(CommandServer, self).__init__(parent)
 
-    ## @brief Method to handle an incomming connection by dispatching a `CommandThread`.
+    ## @brief Method to handle an incoming connection by dispatching a `CommandThread`.
     #
-    #This method is called by Qt when an incomming connection with a socket
+    #This method is called by Qt when an incoming connection with a socket
     #descriptor is received. A new `CommandThread` is created to serve to a received
     #request from the socket description. The `CommandThread` is set to terminate
     #when finished and then started.
@@ -262,8 +262,8 @@ def checkIPIsValid(ip):
 # @param		port	An int selecting a port to be used for the `CommandServer`.
 #
 # @return
-#    An integer error code signifying that and error occured(either
-#    `ERROR_INVALID ADDRESS` or `ERROR_PORT_OCCUPIED`) or a CommnadServer
+#    An integer error code signifying that and error occurred (either
+#    `ERROR_INVALID ADDRESS` or `ERROR_PORT_OCCUPIED`) or a CommandServer
 #    instance if everything went hunky-dory.
 #
 
@@ -318,7 +318,7 @@ class CommandClient:
     # A QTcpSocket used to contact `CommandSErver`
 
     ## @property		blockSize
-    # An int representing size of incomming tcp message.
+    # An int representing size of incoming tcp message.
 
     ## @brief Initialization method for CommandClient.
     #
@@ -338,9 +338,9 @@ class CommandClient:
     ## @brief Method used to send commands from client to `CommandServer`.
     #
     #This method tries to connect to a specified host `CommandServer` via
-    #`tcpSocket`. If connection was successfull, the command `cmd` is sent.
+    #`tcpSocket`. If connection was successful, the command `cmd` is sent.
     #Then the response is expected. If the response is equal to
-    #COMMAND_EXECUTED_CONFIRMATION_MESSAGE, then the execution was successfull.
+    #COMMAND_EXECUTED_CONFIRMATION_MESSAGE, then the execution was successful.
     #The progress and result of `sendCommand` can be obtained from printed logs and
     #return value.
     #
@@ -436,11 +436,11 @@ class CommandClient:
     ## @brief `Qt`'s slot method to print out received `tcpSocket`'s error.
     #
     #QAbstractSocket.RemoteHostClosedError is not printed, because it occurs
-    #naturaly when the `tcpSocket` closes after a transaction is over. Except that
+    #naturally when the `tcpSocket` closes after a transaction is over. Except that
     #all errors are printed.
     #
     #
-    # @param		socketError	A QAbstractSocket::SocketError enum describing occured error.
+    # @param		socketError	A QAbstractSocket::SocketError enum describing occurred error.
     #
 
     def displayError(self, socketError):
@@ -465,7 +465,7 @@ class CommandClient:
 # @param		port	An int of port at which `CommandServer` is listening.
 #
 #
-# @param		wait_time	An int setting miliseconds to wait for connection or message.
+# @param		wait_time	An int setting milliseconds to wait for connection or message.
 #
 # @return
 #    `CLIENT_COMMAND_EXECUTED` if all went great and command was executed.

--- a/Doxygen/GenerateDocumentation.cmd
+++ b/Doxygen/GenerateDocumentation.cmd
@@ -76,7 +76,7 @@ SET output_dir_set=0
 	ECHO(  /O      Specifies an output directory for translated scripts.
 	ECHO(  /D      Specifies a doxygen configuration file to run.
 	ECHO;
-	ECHO This script tranlates python scripts and moves them into an output directory.
+	ECHO This script translates python scripts and moves them into an output directory.
 	ECHO Afterwards it runs a doxygen configuration file. If none of /S, /O and /D command
 	ECHO switches are supplied, then python scripts are looked for in a current directory,
 	ECHO the output directory is "Doxypypy outputs" folder made or existing in 

--- a/Doxygen/css/customdoxygen.css
+++ b/Doxygen/css/customdoxygen.css
@@ -14,7 +14,7 @@ body {
 	visibility: hidden;
 }
 
-/* improove navigation tree */
+/* improve navigation tree */
 #nav-tree {
 	background: #fff;
 	overflow-x: scroll;

--- a/Init.py
+++ b/Init.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *

--- a/InitGui.py
+++ b/InitGui.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *

--- a/Server.py
+++ b/Server.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -137,7 +137,7 @@ Args:
             fp.addProperty("App::PropertyIntegerConstraint", "Port",
                            "Server settings", "Port where the server will "
                            + "listen for connections.\n" +
-                           "Valid port numers are in range <0 | 65535>,\n"
+                           "Valid port numbers are in range <0 | 65535>,\n"
                            + "but some may be already taken!"
                            ).Port = (54321, 0, 65535, 1)
         else:
@@ -377,7 +377,7 @@ Args:
 
 class ServerCommand(object):
     """
-ServerCommand class specifing Animate workbench's Server button/command.
+ServerCommand class specifying Animate workbench's Server button/command.
 
 This class provides resources for a toolbar button and a menu button.
 It controls their behaivor(Active/Inactive) and responds to callbacks after

--- a/Trajectory.py
+++ b/Trajectory.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -611,7 +611,7 @@ Args:
 
     def change_trajectory(self, fp, traj):
         """
-Metod used to change a `Trajectory`'s trajectory.
+Method used to change a `Trajectory`'s trajectory.
 
 A `traj` dictionary containing a trajectory is tested for validity and then
 assigned to a `Trajectory` `DocumentObjectGroupPython`.
@@ -750,7 +750,7 @@ Returns:
 Method to find weighted `timestamps` indices corresponding to a given `time`.
 
 If a `time` is smaller than the first timestamp, the returned indices are [0,0]
-with weights [1,0] as that's the closest value. Simlarly, if the `time` is
+with weights [1,0] as that's the closest value. Similarly, if the `time` is
 greater than the last timestamp, the returned indices are [-1,-1] pointing to
 the last element of a `timestamps` list with weights [1,0]. If the `time` value
 is between the first and last timestamp, the indices belong to the closest
@@ -1147,7 +1147,7 @@ then invokes `claimChildren()`.
 
     def canDropObject(self, obj):
         """
-Method called by FreeCAD to ask if an object `obj` can be droped into a Group.
+Method called by FreeCAD to ask if an object `obj` can be dropped into a Group.
 
 Only FreeCAD objects of a Trajectory type are allowed to drop inside
 a Trajectory group.
@@ -1216,7 +1216,7 @@ Method called by FreeCAD when Trajectory is double-clicked in the Tree View.
 If no dialog is opened in the Task View, a new `TrajectoryPanel` is opened.
 If another `TrajectoryPanel` is opened, it is closed and all its QDialogs
 are added to a new `TrajectoryPanel`. If a `TrajectoryPanel` is already opened,
-the Model tab on the Combo View is swaped for the Tasks tab so that the panel
+the Model tab on the Combo View is swapped for the Tasks tab so that the panel
 becomes visible. If another dialog is opened a warning is shown.
 
 Args:
@@ -1480,7 +1480,7 @@ Returns:
 
 class TrajectoryCommand(object):
     """
-Class specifing Animate workbench's Trajectory button/command.
+Class specifying Animate workbench's Trajectory button/command.
 
 This class provides resources for a toolbar button and a menu button.
 It controls their behaivor(Active/Inactive) and responds to callbacks after

--- a/communication.py
+++ b/communication.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Animate workbench - FreeCAD Workbench for lightweigh animation        *
+# *   Animate workbench - FreeCAD Workbench for lightweight animation       *
 # *   Copyright (c) 2019 Jiří Valášek jirka362@gmail.com                    *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -41,8 +41,8 @@ from PySide2.QtCore import QThread, QByteArray, QDataStream, QIODevice
 from PySide2.QtNetwork import QTcpServer, QTcpSocket, QAbstractSocket, \
                               QHostAddress
 
-## Size of uint16 in bytes used to leave space at the beggining of each message
-# to specify tcp message lenght (maximal length is 65535 bytes).
+## Size of uint16 in bytes used to leave space at the beginning of each message
+# to specify tcp message length (maximal length is 65535 bytes).
 SIZEOF_UINT16 = 2
 
 ## Error code used in startServer() when trying to connect CommandServer to an
@@ -53,15 +53,15 @@ SERVER_ERROR_INVALID_ADDRESS = 1
 # occupied port.
 SERVER_ERROR_PORT_OCCUPIED = 2
 
-## Time to wait in miliseconds - used to wait for incomming message etc.
+## Time to wait in milliseconds - used to wait for incoming message etc.
 WAIT_TIME_MS = 30000
 
 ## Message send from a `CommandServer` to a `CommandClient.sendCommand()` or
-# `sendClientCommand()` after successfull execution of a command.
+# `sendClientCommand()` after successful execution of a command.
 COMMAND_EXECUTED_CONFIRMATION_MESSAGE = "Command executed successfully"
 
 ## `CommandClient.sendCommand()` or `sendClientCommand()` return value after
-# confirmation of successfull command execution.
+# confirmation of successful command execution.
 CLIENT_COMMAND_EXECUTED = 0
 
 ## `CommandClient.sendCommand()` or `sendClientCommand()` return value if
@@ -91,11 +91,11 @@ class CommandThread(QThread):
 
 This class describes a `QThread` used to receive a command string from
 a `QTcpSocket`, try to execute received string and send a repspondse
-whether the execution was successfull or not.
+whether the execution was successful or not.
 
 Attributes:
     socketDescriptor: A Qt's qintptr socket descriptor to initialize tcpSocket.
-    blockSize: An int representing size of incomming tcp message.
+    blockSize: An int representing size of incoming tcp message.
     """
 
     def __init__(self, socketDescriptor, parent):
@@ -119,20 +119,20 @@ Thread's functionality method.
 
 The starting point for the thread. After calling start(), the newly created
 thread calls this function. This function then tries to make QTcpSocket.
-It waits `WAIT_TIME_MS` for an incomming message. If message is received
+It waits `WAIT_TIME_MS` for an incoming message. If message is received
 it checks its a whole message using blockSize sent in the first word as
 an UINT16 number. If a whole message is received, the thread tries to execute
 the message string and sends back an appropriate response. The response is
-*Command failed - "error string"* if the execution failed, or *Commmand
+*Command failed - "error string"* if the execution failed, or *Command
 executed successfully* otherwise. Then the thread is terminated.
         """
-        # Try to connect to an incomming tcp socket using its socket descriptor
+        # Try to connect to an incoming tcp socket using its socket descriptor
         tcpSocket = QTcpSocket()
         if not tcpSocket.setSocketDescriptor(self.socketDescriptor):
             FreeCAD.Console.PrintError("Socket not accepted.\n")
             return
 
-        # Wait for an incomming message
+        # Wait for an incoming message
         if not tcpSocket.waitForReadyRead(msecs=WAIT_TIME_MS):
             FreeCAD.Console.PrintError("No request send.\n")
             return
@@ -164,7 +164,7 @@ executed successfully* otherwise. Then the thread is terminated.
                                        + str(e) + "\n")
             message = "Command failed - " + str(e)
         else:
-            FreeCAD.Console.PrintLog("Executing external command succeded!\n")
+            FreeCAD.Console.PrintLog("Executing external command succeeded!\n")
             message = COMMAND_EXECUTED_CONFIRMATION_MESSAGE
 
         # Prepare the data block to send back and inform about it
@@ -203,9 +203,9 @@ Args:
 
     def incomingConnection(self, socketDescriptor):
         """
-Method to handle an incomming connection by dispatching a `CommandThread`.
+Method to handle an incoming connection by dispatching a `CommandThread`.
 
-This method is called by Qt when an incomming connection with a socket
+This method is called by Qt when an incoming connection with a socket
 descriptor is received. A new `CommandThread` is created to serve to a received
 request from the socket description. The `CommandThread` is set to terminate
 when finished and then started.
@@ -260,8 +260,8 @@ Args:
     port: An int selecting a port to be used for the `CommandServer`.
 
 Returns:
-    An integer error code signifying that and error occured(either
-    `ERROR_INVALID ADDRESS` or `ERROR_PORT_OCCUPIED`) or a CommnadServer
+    An integer error code signifying that and error occurred(either
+    `ERROR_INVALID ADDRESS` or `ERROR_PORT_OCCUPIED`) or a CommandServer
     instance if everything went hunky-dory.
     """
 
@@ -298,7 +298,7 @@ Attributes:
     host: A QtHostAddress to the `CommandServer`.
     port: An int of port at which `CommandServer` is listening.
     tcpSocket: A QTcpSocket used to contact `CommandSErver`
-    blockSize: An int representing size of incomming tcp message.
+    blockSize: An int representing size of incoming tcp message.
 
     from PySide2.QtNetwork import QHostAddress
     from communication import CommandClient
@@ -327,9 +327,9 @@ Args:
 Method used to send commands from client to `CommandServer`.
 
 This method tries to connect to a specified host `CommandServer` via
-`tcpSocket`. If connection was successfull, the command `cmd` is sent.
+`tcpSocket`. If connection was successful, the command `cmd` is sent.
 Then the response is expected. If the response is equal to
-COMMAND_EXECUTED_CONFIRMATION_MESSAGE, then the execution was successfull.
+COMMAND_EXECUTED_CONFIRMATION_MESSAGE, then the execution was successful.
 The progress and result of `sendCommand` can be obtained from printed logs and
 return value.
 
@@ -425,11 +425,11 @@ Returns:
 `Qt`'s slot method to print out received `tcpSocket`'s error.
 
 QAbstractSocket.RemoteHostClosedError is not printed, because it occurs
-naturaly when the `tcpSocket` closes after a transaction is over. Except that
+naturally when the `tcpSocket` closes after a transaction is over. Except that
 all errors are printed.
 
 Args:
-    socketError: A QAbstractSocket::SocketError enum describing occured error.
+    socketError: A QAbstractSocket::SocketError enum describing occurred error.
         """
         if socketError != QAbstractSocket.RemoteHostClosedError:
             if "FreeCAD" in sys.modules:
@@ -454,7 +454,7 @@ Args:
     port: An int of port at which `CommandServer` is listening.
 
 Kwargs:
-    wait_time: An int setting miliseconds to wait for connection or message.
+    wait_time: An int setting milliseconds to wait for connection or message.
 
 Returns:
     `CLIENT_COMMAND_EXECUTED` if all went great and command was executed.


### PR DESCRIPTION
Found using `codespell -q 3 -L ba,currenty`